### PR TITLE
Update README.md - "How to run on Android" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In all cases you will run `XXX_desktop` demos.
 
 ## How to run on Android
 
-Refer to [android-go/example](https://github.com/xlab/android-go/tree/master/example)
+Refer to [xlab/android-go](https://github.com/xlab/android-go)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In all cases you will run `XXX_desktop` demos.
 
 ## How to run on Android
 
-Refer to [xlab/android-go](https://github.com/xlab/android-go)
+Refer to [xlab/android-go/examples/minimal](https://github.com/xlab/android-go/tree/master/examples/minimal)
 
 ## License
 


### PR DESCRIPTION
The current link for the android example is broken ( https://github.com/xlab/android-go/tree/master/example ), and should be changed to ( https://github.com/xlab/android-go/tree/master/examples/minimal ) that has a README.md that explains the process.