### PR TITLE
Add go.mod file to allow easier running

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,27 @@
-Golang Vulkan API Demos
-=======================
+# Golang Vulkan API Demos
 
-* vulcaninfo
-* vulcandraw
-* vulcancube
+- vulcaninfo
+- vulcandraw
+- vulcancube
 
 ## Supported platforms
 
-* Windows (GLFW)
-* Android (Native)
-* Linux graphics (GLFW)
-* Linux computing (X11)
-* OS X / macOS (GLFW + MoltenVK)
-* iOS (Metal + MoltenVK)
+- Windows (GLFW)
+- Android (Native)
+- Linux graphics (GLFW)
+- Linux computing (X11)
+- OS X / macOS (GLFW + MoltenVK)
+- iOS (Metal + MoltenVK)
 
 ## How to run on desktops
+
+### GLFW v3.3
+
+A standard `go run main.go` / `go build` in each of the glfw demo folders should work out of the box for most platforms.
+
+For macOS / iOS the MoltenVK.framework needs to be installed in the /Library/Frameworks folder for the build to find it. It can be downloaded as part of he Vulkan SDK: https://vulkan.lunarg.com/sdk/home
+
+### Manual configuration
 
 For **OS X / macOS** you'll need to install the latest GLFW 3.3 from master https://github.com/glfw/glfw
 and prepare MoltenVK https://moltengl.com/moltenvk/ SDK beforehand so CMake could find it.
@@ -24,8 +31,9 @@ There is a Makefile https://github.com/vulkan-go/demos/blob/master/vulkancube/vu
 For **Windows** you don't need to compile MoltenVK and can use GLFW 3.2.1 distro from the site http://www.glfw.org then just specify paths in Makefile or run commands by hand, specifying paths to GLFW distro folders.
 
 Make sure your graphics card and driver are supported:
-* https://developer.nvidia.com/vulkan-driver
-* http://www.amd.com/en-us/innovations/software-technologies/technologies-gaming/vulkan
+
+- https://developer.nvidia.com/vulkan-driver
+- http://www.amd.com/en-us/innovations/software-technologies/technologies-gaming/vulkan
 
 In all cases you will run `XXX_desktop` demos.
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/vulkan-go/demos
+
+go 1.15
+
+require (
+	github.com/vulkan-go/asche v0.0.0-20190912134304-d4b318b67e07
+	github.com/vulkan-go/glfw v0.0.0-20190520160600-32f33e359ff2
+	github.com/vulkan-go/vulkan v0.0.0-20200123094538-aa511c71e200
+	github.com/xlab/closer v0.0.0-20190328110542-03326addb7c2
+	github.com/xlab/linmath v0.0.0-20170502193301-512668b827be
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/vulkan-go/asche v0.0.0-20190912134304-d4b318b67e07 h1:QIXP1nx5b+YZt1cKDP5SR/89tRXrLxWslBBFBvH/+Y0=
+github.com/vulkan-go/asche v0.0.0-20190912134304-d4b318b67e07/go.mod h1:fIbNY6YffQRtdF22h26OXRprI/BGOWPKlxJWtNC78OA=
+github.com/vulkan-go/glfw v0.0.0-20190520160600-32f33e359ff2 h1:jPnSXM1EM+6J1MbKbUZvQWkuS6Z9lPWRxTHn1NPsyNY=
+github.com/vulkan-go/glfw v0.0.0-20190520160600-32f33e359ff2/go.mod h1:qui9jo5J26j9fXv2x3bySGThxYkQZt4SgsPIZRtZAbQ=
+github.com/vulkan-go/vulkan v0.0.0-20200123094538-aa511c71e200 h1:Gd8JCplUKwEoAx/9s/zL9DQzNdxmWidxd2uM4zVpURw=
+github.com/vulkan-go/vulkan v0.0.0-20200123094538-aa511c71e200/go.mod h1:X6Qqg0j5A5cYHhFXUOl6TL/vYdyh/ajvyCvh+sEHQFI=
+github.com/xlab/closer v0.0.0-20190328110542-03326addb7c2 h1:LPYwXwwHigHHFX3SFa9W9zBIa5reyaLJos2e95eHh68=
+github.com/xlab/closer v0.0.0-20190328110542-03326addb7c2/go.mod h1:Y8IYP9aVODN3Vnw1FCqygCG5IWyYBeBlZqQ5aX+fHFw=
+github.com/xlab/linmath v0.0.0-20170502193301-512668b827be h1:J/lWrXhpS1n3HRy18iqZnIhQqGSrvKnXQpVRNG5rKqM=
+github.com/xlab/linmath v0.0.0-20170502193301-512668b827be/go.mod h1:fgIYDv0Jdzzt+7Us/LdHhBL5N7xqDoj7Jgyf9da1mH4=


### PR DESCRIPTION
Adds go.mod file to allow running demos with `go run main.go` or building with `go build`. Also updates the readme with a note about installing the MoltenVK.framework for easier builds.